### PR TITLE
feat(user): fetch and display the header and details view of the user signature data

### DIFF
--- a/app-modules/app/components/base/Button.vue
+++ b/app-modules/app/components/base/Button.vue
@@ -1,92 +1,23 @@
 <script setup lang="ts">
-import type { ButtonType } from '~/app-modules/app/types/html'
+import Typography from '@/enums/Typography'
 
-interface Props {
-  disabled?: boolean
-  pure?: boolean
-  type?: ButtonType
-  theme?: 'primary' | null
-  size?: 'small' | null
+interface LinkProps {
+  label: string
   href?: string
 }
 
-const {
-  disabled = false,
-  pure = false,
-  type = 'button',
-  theme = null,
-  size = null,
-  href = null,
-} = defineProps<Props>()
+const props = defineProps<LinkProps>()
 
-const onClient = computed(() => !process.server)
-const isLink = href?.length
-
-const buttonClasses = computed(() => ({
-  'button': true,
-  [`is-${theme}`]: theme && !pure,
-  [`button--${size}`]: size,
-  'button--pure': pure,
-  'button--disabled': disabled,
-  'button--hydrating': !onClient,
-}))
+const isLink = props.href?.length
 </script>
 
 <template>
-  <span class="b-button">
-    <component
-      :is="isLink ? 'a' : 'button'"
-      :class="buttonClasses"
-      :type="type"
-      :aria-disabled="disabled"
-      @click.stop="$emit('click')"
-    >
-      <slot />
-    </component>
-  </span>
+  <component
+    :is="isLink ? 'a' : 'button'"
+    :href="href"
+    class="c-btn"
+    target="_blank"
+  >
+    <BaseText :type="Typography.BUTTON" :label="label" />
+  </component>
 </template>
-
-<style scoped>
-.b-button {
-  display: inline-block;
-}
-
-/* Show a loading state if user hovers over button after SSR, but before JavaScript has hydrated and taken over clientside */
-.button--hydrating {
-  cursor: wait;
-}
-
-.button--disabled {
-  cursor: no-drop;
-}
-
-.button {
-  align-items: center;
-  border: 1px solid transparent;
-  border-radius: 9999px;
-  box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-  color: #000;
-  display: inline-flex;
-  /* font-family: theme('fontFamily.body'); */
-  font-size: var(--button-font-size, 1rem);
-  height: max-content;
-  justify-content: center;
-  padding: var(--button-padding-y, 0.65rem) var(--button-padding-x, 1rem);
-  width: 100%;
-}
-
-.button--disabled {
-  pointer-events: none;
-}
-
-.button--small {
-  font-size: var(--button-small-font-size, 0.875rem);
-  padding: var(--button-small-padding-y, 0.4rem) var(--button-small-padding-x, 1rem);
-}
-
-.button--pure {
-  box-shadow: unset;
-  min-width: unset;
-  padding: unset;
-}
-</style>

--- a/app-modules/app/components/base/ProgressBar.vue
+++ b/app-modules/app/components/base/ProgressBar.vue
@@ -1,0 +1,24 @@
+<script lang="ts" setup></script>
+
+<template>
+  <!-- Placeholder content -->
+  <progress id="file" class="c-progress u-mb-14" max="42" value="8">
+    20%
+  </progress>
+</template>
+
+<style scoped lang="scss">
+.c-progress {
+  width: 100%;
+  &::-webkit-progress-value{
+    background: theme('colors.blue');
+    border-radius: 20px;
+    width: 100%;
+  }
+  &::-webkit-progress-bar {
+  border-radius: 20px;
+
+    background: theme('colors.grey');
+  }
+}
+</style>

--- a/app-modules/app/components/base/Text.vue
+++ b/app-modules/app/components/base/Text.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import Typography from '~/enums/Typography'
+
+interface TextProps {
+  type: Typography
+  label: string
+  id?: string
+}
+
+const props = defineProps<TextProps>()
+
+const componentDefinition = computed(() => {
+  switch (props.type) {
+    case Typography.H1:
+      return 'h1'
+    case Typography.H2:
+      return 'h2'
+    case Typography.H3:
+      return 'h3'
+    case Typography.H4:
+      return 'h4'
+    case Typography.BUTTON:
+      return 'span'
+    default:
+      return 'p'
+  }
+})
+</script>
+
+<template>
+  <component :is="componentDefinition" :id="id" :class="type">
+    {{ label }}
+  </component>
+</template>

--- a/app-modules/app/components/ui/User.vue
+++ b/app-modules/app/components/ui/User.vue
@@ -1,0 +1,21 @@
+<script lang="ts" setup>
+import { useUserStore } from '@/stores/user'
+
+const userStore = useUserStore()
+</script>
+
+<template>
+  <section id="c-user" class="o-wrapper">
+    <div class="c-user">
+      <UserHeader :full-name="userStore.getUserFullName" />
+
+      <UserDetails :user="userStore.getUserDetails" />
+
+      <div class="c-user__strengths" />
+
+      <div class="c-user__focuses" />
+    </div>
+  </section>
+</template>
+
+<style scoped></style>

--- a/app-modules/app/components/user/Details.vue
+++ b/app-modules/app/components/user/Details.vue
@@ -1,0 +1,33 @@
+<script lang="ts" setup>
+import type { PropType } from 'vue'
+import Typography from '@/enums/Typography'
+import type { UserDetailsProps } from '@/app-modules/app/types/user'
+
+const props = defineProps({
+  user: {
+    type: Object as PropType<UserDetailsProps>,
+    required: true,
+  },
+})
+</script>
+
+<template>
+  <div class="c-user__details">
+    <div class="c-user__info">
+      <BaseText :type="Typography.TAG" label="Member since" />
+      <BaseText :type="Typography.BODY_LARGE_BOLD" :label="user.memberSince" class="u-mb-16" />
+      <BaseText :type="Typography.TAG" label="Character Qualities awarded" />
+      <BaseText :type="Typography.BODY_LARGE_BOLD" label="12" />
+    </div>
+
+    <div class="c-user__goal">
+      <BaseText :type="Typography.H2" label="Learning Goals" class="u-mb-16" />
+      <BaseText :type="Typography.TAG" label="I am becoming" />
+      <BaseText :type="Typography.BODY_LARGE_BOLD" :label="user.progressTitle" class="u-mb-16" />
+      <BaseProgressBar />
+      <BaseText :type="Typography.BODY_LARGE_REGULAR" :label="user.progressDesc" />
+    </div>
+  </div>
+</template>
+
+<style scoped></style>

--- a/app-modules/app/components/user/Header.vue
+++ b/app-modules/app/components/user/Header.vue
@@ -1,0 +1,22 @@
+<script lang="ts" setup>
+import Typography from '@/enums/Typography'
+
+interface UserHeaderProps {
+  fullName: string
+}
+
+const props = defineProps<UserHeaderProps>()
+</script>
+
+<template>
+  <div class="c-user__header">
+    <div class="c-user__name">
+      <BaseText :type="Typography.H1" :label="fullName" />
+    </div>
+    <div class="c-user__cta">
+      <BaseButton href="https://entelechy.academy" label="Get your own signature" />
+    </div>
+  </div>
+</template>
+
+<style scoped></style>

--- a/app-modules/app/types/user.ts
+++ b/app-modules/app/types/user.ts
@@ -1,0 +1,32 @@
+export interface User {
+  first_name: string
+  last_name: string
+  created_at: string
+  progress_title: string
+  progress_desc: string
+  strenghts: userStrength[]
+  focuses: userFocuses[]
+}
+
+export interface userStrength {
+  name: string
+  verified: number
+  thumb: string
+  rating: number
+  awarded: number
+}
+
+export interface userFocuses {
+  name: string
+  thumb: string
+  status: string
+  progress_tally: number
+  progress_total: number
+  awarded: number
+}
+
+export interface UserDetailsProps {
+  memberSince: string
+  progressTitle: string
+  progressDesc: string
+}

--- a/app.vue
+++ b/app.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 useHead({
-  title: 'Entelechy - Signature',
+  title: 'Entelechy Signature',
   link: [{ rel: 'icon', href: '/favicon.ico' }],
 })
 </script>

--- a/assets/styles/components/_index.scss
+++ b/assets/styles/components/_index.scss
@@ -1,1 +1,2 @@
 @forward './btn';
+@forward './user';

--- a/assets/styles/components/_user.scss
+++ b/assets/styles/components/_user.scss
@@ -1,0 +1,22 @@
+.c-user {
+  display: grid;
+  grid-template-rows: repeat(4, auto);
+  gap: theme('spacing.40');
+  padding-top: theme('spacing.40');
+
+  &__header {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  &__details {
+    width: 100%;
+    display: grid;
+    grid-template-columns: 22.5% 72.5%;
+    gap: 5%;
+  }
+
+
+}

--- a/helpers/formatDate.ts
+++ b/helpers/formatDate.ts
@@ -1,4 +1,4 @@
 export default function formatDate(dateStr: string): string {
   const date = new Date(dateStr)
-  return date.toLocaleDateString(undefined, {day: 'numeric', month: 'long', year: 'numeric' })
+  return date.toLocaleDateString(undefined, { day: 'numeric', month: 'long', year: 'numeric' })
 }

--- a/pages/[id].vue
+++ b/pages/[id].vue
@@ -1,8 +1,16 @@
 <script setup lang="ts">
+import { useRoute } from 'vue-router'
+import { useUserStore } from '@/stores/user'
+
+const route = useRoute()
+
+const userStore = useUserStore()
+userStore.getUser(String(route.params.id))
 </script>
 
 <template>
   <UiHeader />
+  <UiUser />
 </template>
 
 <style></style>

--- a/queries/data.gql
+++ b/queries/data.gql
@@ -1,0 +1,23 @@
+mutation Signature($id: ID = 1) {
+    getSigData(id: $id) {
+        first_name
+        last_name
+        created_at
+        progress_title
+        progress_desc
+        strengths {
+            name
+            verified
+            thumb
+            rating
+        }
+        focuses {
+            name
+            thumb
+            status
+            progress_tally
+            progress_total
+            awarded
+        }
+    }
+}

--- a/stores/user.ts
+++ b/stores/user.ts
@@ -1,0 +1,38 @@
+import { defineStore } from 'pinia'
+import type { User, UserDetailsProps } from '@/app-modules/app/types/user'
+import formatDate from '@/helpers/formatDate'
+
+export const useUserStore = defineStore('user', {
+  state: () => ({
+    userData: null,
+    user: {} as User,
+  }),
+
+  getters: {
+    getUserFullName: (state): string => `${state.user.first_name} ${state.user.last_name}`,
+
+    getMemberSinceDate: (state): string => formatDate(state.user.created_at),
+
+    getUserDetails(state) {
+      return {
+        memberSince: this.getMemberSinceDate,
+        progressTitle: state.user.progress_title || 'Placeholder: A Manager of Systems',
+        progressDesc: state.user.progress_desc || 'Placeholder: To become someone who integrates all operational components to improve performance and achieve the best outcome.',
+      } as UserDetailsProps
+    },
+
+    setUser: state => state.user = state.userData?.data.getSigData,
+  },
+
+  actions: {
+    async getUser(userId: string) {
+      try {
+        this.userData = await useAsyncData('data', () => GqlSignature({ id: userId }))
+        this.setUser
+      }
+      catch (error) {
+        return error
+      }
+    },
+  },
+})

--- a/types/user.ts
+++ b/types/user.ts
@@ -1,0 +1,32 @@
+export interface User {
+  first_name: string
+  last_name: string
+  created_at: string
+  progress_title: string
+  progress_desc: string
+  strenghts: userStrength[]
+  focuses: userFocuses[]
+}
+
+export interface userStrength {
+  name: string
+  verified: number
+  thumb: string
+  rating: number
+  awarded: number
+}
+
+export interface userFocuses {
+  name: string
+  thumb: string
+  status: string
+  progress_tally: number
+  progress_total: number
+  awarded: number
+}
+
+export interface UserDetailsProps {
+  memberSince: string
+  progressTitle: string
+  progressDesc: string
+}


### PR DESCRIPTION
This PR implements the following:

- The ability to perform GraphQL queries/mutations to get the user's signature data
- Implement Pinia to store the data received from the API
- Display the user data by ID (visit /[ID] to see different user data)
- Dislpay the users header and details of the user's signature data

### Preview of build:

Homepage:
- https://cq-signature-git-feat-user-entelechy.vercel.app/
- @TODO ask UI for a design for this page

User's Signature Data
- https://cq-signature-git-feat-user-entelechy.vercel.app/1
- @TODO loading state?